### PR TITLE
introduce client.Client and client.SingleFlight

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/mgechev/revive v1.3.4
 	github.com/miekg/dns v1.1.57
 	golang.org/x/net v0.19.0
+	golang.org/x/sync v0.5.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,7 @@ golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
 golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
 golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
+golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=

--- a/iterator.go
+++ b/iterator.go
@@ -9,6 +9,7 @@ import (
 	"darvaza.org/core"
 	"github.com/miekg/dns"
 
+	"darvaza.org/resolver/pkg/client"
 	"darvaza.org/resolver/pkg/errors"
 )
 
@@ -34,7 +35,7 @@ var roots = map[string]string{
 // RootLookuper does iterative lookup using the given root-server
 // as starting point
 type RootLookuper struct {
-	c     *dns.Client
+	c     client.Client
 	Start string
 }
 
@@ -64,11 +65,10 @@ func NewRootLookuper(start string) (*RootLookuper, error) {
 
 func newRootLookuperUnchecked(start string) *RootLookuper {
 	c := new(dns.Client)
-	c.SingleInflight = true
 	c.UDPSize = DefaultUDPSize
 
 	return &RootLookuper{
-		c:     c,
+		c:     client.NewSingleFlight(c, 0),
 		Start: start,
 	}
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,0 +1,24 @@
+// Package client implements DNS client wrappers
+package client
+
+import (
+	"context"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+var (
+	_ Client = (*dns.Client)(nil)
+)
+
+// A Client makes a request to a server
+type Client interface {
+	ExchangeContext(context.Context, *dns.Msg, string) (*dns.Msg, time.Duration, error)
+}
+
+// NewDefaultClient allocate a default [dns.Client] in the same
+// manner as dns.ExchangeContext(), plain UDP.
+func NewDefaultClient() Client {
+	return &dns.Client{Net: "udp"}
+}

--- a/pkg/client/singleflight.go
+++ b/pkg/client/singleflight.go
@@ -1,0 +1,172 @@
+package client
+
+import (
+	"context"
+	"time"
+
+	"github.com/miekg/dns"
+	"golang.org/x/sync/singleflight"
+
+	"darvaza.org/resolver/pkg/errors"
+)
+
+var (
+	_ Client = (*SingleFlight)(nil)
+)
+
+const (
+	// DefaultSingleFlightExpiration tells how long will we cache
+	// the result after an exchange
+	DefaultSingleFlightExpiration = 1 * time.Second
+)
+
+// SingleFlight wraps a [Client] to minimize redundant queries
+type SingleFlight struct {
+	c   Client
+	g   singleflight.Group
+	exp time.Duration
+}
+
+// ExchangeContext makes a DNS query to a server, minimizing duplications.
+func (sfc *SingleFlight) ExchangeContext(ctx context.Context, req *dns.Msg,
+	server string) (*dns.Msg, time.Duration, error) {
+	//
+	if ctx == nil || req == nil {
+		return nil, 0, errors.ErrBadRequest()
+	}
+
+	switch len(req.Question) {
+	case 0:
+		// nothing to answer
+		msg := new(dns.Msg)
+		msg.SetReply(req)
+		return msg, 0, nil
+	case 1:
+		// ready
+	default:
+		// shrink
+		req.Question = []dns.Question{req.Question[0]}
+	}
+
+	if req.Id == 0 {
+		// make sure we have a unique Id for future
+		// disambiguation
+		req.Id = dns.Id()
+	}
+
+	return sfc.doExchange(ctx, req, server)
+}
+
+func (sfc *SingleFlight) doExchange(ctx context.Context, req *dns.Msg,
+	server string) (*dns.Msg, time.Duration, error) {
+	//
+	key := sfc.RequestKey(req, server)
+	v, err, shared := sfc.g.Do(key, func() (any, error) {
+		// TODO: how to allow retries on error properly?
+		data, err := sfc.doExchangeResult(ctx, req, server)
+
+		sfc.deferredExpiration(key)
+
+		return data, err
+	})
+
+	data, ok := v.(sfResult)
+	if !ok {
+		panic("unreachable")
+	}
+
+	return data.Export(req, err, shared)
+}
+
+func (sfc *SingleFlight) deferredExpiration(key string) {
+	switch {
+	case sfc.exp > 0:
+		// deferred expiration
+		go func(key string) {
+			<-time.After(sfc.exp)
+			sfc.g.Forget(key)
+		}(key)
+	default:
+		// immediate
+		sfc.g.Forget(key)
+	}
+}
+
+func (sfc *SingleFlight) doExchangeResult(ctx context.Context, req *dns.Msg,
+	server string) (sfResult, error) {
+	//
+	if sfc.c == nil {
+		// it doesn't matter if this happens multiple times
+		// and will only happens if the user didn't use
+		// NewSingleFlight()
+		sfc.c = NewDefaultClient()
+	}
+
+	res, rtt, err := sfc.c.ExchangeContext(ctx, req, server)
+
+	data := sfResult{
+		res: res,
+		rtt: rtt,
+	}
+
+	return data, err
+}
+
+// RequestKey serializes a DNS request to act as temporary cache key
+func (*SingleFlight) RequestKey(req *dns.Msg, server string) string {
+	var key string
+
+	if req != nil {
+		// serialize the whole request, except the Id.
+		// TODO: could we do better?
+		r2 := req.Copy()
+		r2.Id = 0
+
+		key = r2.String()
+	}
+
+	switch {
+	case server == "":
+		return key
+	case key == "":
+		return server
+	default:
+		return key + "\n; " + server
+	}
+}
+
+type sfResult struct {
+	res *dns.Msg
+	rtt time.Duration
+}
+
+// revive:disable:flag-parameter
+func (d sfResult) Export(req *dns.Msg, err error, shared bool) (*dns.Msg, time.Duration, error) {
+	// revive:enable:flag-parameter
+	res := d.res
+	rtt := d.rtt
+
+	if shared && res != nil {
+		res = res.Copy()
+		res.Id = req.Id
+	}
+
+	return res, rtt, err
+}
+
+// NewSingleFlight creates a [SingleFlight] Client around another.
+// if no Client is specified, the default udp dns.Client will be used.
+// if exp is positive, the result will be cached that long.
+// if exp is negative, the result will expire immediately
+// if exp is zero, [DefaultSingleFlightExpiration] will be used
+func NewSingleFlight(c Client, exp time.Duration) *SingleFlight {
+	if c == nil {
+		c = NewDefaultClient()
+	}
+
+	if exp == 0 {
+		exp = DefaultSingleFlightExpiration
+	}
+
+	return &SingleFlight{c: c, exp: exp}
+}

--- a/single.go
+++ b/single.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"context"
 
+	"darvaza.org/resolver/pkg/client"
 	"darvaza.org/resolver/pkg/errors"
 	"github.com/miekg/dns"
 )
@@ -15,7 +16,7 @@ var (
 // SingleLookuper asks a single server for a direct answer
 // to the query preventing repetition
 type SingleLookuper struct {
-	c         *dns.Client
+	c         client.Client
 	remote    string
 	recursive bool
 }
@@ -62,11 +63,10 @@ func NewSingleLookuper(server string, recursive bool) (*SingleLookuper, error) {
 
 func newSingleLookuperUnsafe(server string, recursive bool) *SingleLookuper {
 	c := new(dns.Client)
-	c.SingleInflight = true
 	c.UDPSize = DefaultUDPSize
 
 	return &SingleLookuper{
-		c:         c,
+		c:         client.NewSingleFlight(c, 0),
 		remote:    server,
 		recursive: recursive,
 	}


### PR DESCRIPTION
and use it to replace the no-op `dns.Client#SingleInflight` and add one-second caching to block some stampedes