### PR TITLE
iterator: introduce initial `IteratorLookuper` and refactor `RootLookuper` using it

### DIFF
--- a/cache_ns_zone.go
+++ b/cache_ns_zone.go
@@ -86,11 +86,18 @@ func (zone *NSCacheZone) IsValid() bool {
 // SetTTL sets the expiration and half-life times in
 // seconds from Now.
 func (zone *NSCacheZone) SetTTL(ttl, half uint32) {
-	if ttl < MinimumNSCacheTTL {
+	switch {
+	case ttl == 0 && half == 0:
+		// apply defaults
+		ttl = MinimumNSCacheTTL
+		half = ttl / 2
+	case ttl < MinimumNSCacheTTL:
+		// too short, but preserve the half-life value.
 		ttl = MinimumNSCacheTTL
 	}
 
 	if half >= ttl {
+		// half-life needs to be lower than the maximum.
 		half = ttl / 2
 	}
 

--- a/iterator.go
+++ b/iterator.go
@@ -2,20 +2,26 @@ package resolver
 
 import (
 	"context"
-	"fmt"
-	"net"
 	"net/netip"
+	"sync"
+	"time"
+
+	"github.com/miekg/dns"
 
 	"darvaza.org/core"
-	"github.com/miekg/dns"
+	"darvaza.org/slog"
 
 	"darvaza.org/resolver/pkg/client"
 	"darvaza.org/resolver/pkg/errors"
 	"darvaza.org/resolver/pkg/exdns"
 )
 
-var _ Lookuper = (*RootLookuper)(nil)
-var _ Exchanger = (*RootLookuper)(nil)
+var (
+	_ Lookuper  = (*RootLookuper)(nil)
+	_ Exchanger = (*RootLookuper)(nil)
+	_ Lookuper  = (*IteratorLookuper)(nil)
+	_ Exchanger = (*IteratorLookuper)(nil)
+)
 
 var roots = map[string]string{
 	"a.root-servers.net": "198.41.0.4",
@@ -33,11 +39,13 @@ var roots = map[string]string{
 	"m.root-servers.net": "202.12.27.33",
 }
 
-// RootLookuper does iterative lookup using the given root-server
-// as starting point
+// deadline used when the iterator needs to make extra queries
+// not governed by the initial Lookup/Exchange.
+const iteratorDeadline = 1 * time.Second
+
+// RootLookuper does iterative lookup using the root servers.
 type RootLookuper struct {
-	c     client.Client
-	Start string
+	l *IteratorLookuper
 }
 
 // NewRootLookuper creates a RootLookuper using the indicated root, or random
@@ -53,39 +61,23 @@ func NewRootLookuperWithClient(start string, c client.Client) (*RootLookuper, er
 }
 
 func safeNewRootLookuper(start string, c client.Client) (*RootLookuper, error) {
-	if c == nil {
-		// use default singleflight client
-		c1 := client.NewDefaultClient(0)
-		c = client.NewSingleFlight(c1, 0)
-	}
+	var err error
+
+	l := NewIteratorLookuper("root", 0, c)
 
 	if start == "" {
-		return newRootLookuperUnchecked(pickRoot(), c), nil
+		err = l.AddRootServers()
+	} else {
+		err = l.AddFrom(".", 0, start)
 	}
 
-	for _, addr := range roots {
-		if start == addr {
-			return newRootLookuperUnchecked(addr, c), nil
-		}
+	if err != nil {
+		return nil, err
 	}
 
-	if addr, ok := roots[start]; ok {
-		return newRootLookuperUnchecked(addr, c), nil
-	}
-
-	err := &net.DNSError{
-		Err:  "invalid root server",
-		Name: start,
-	}
-
-	return nil, err
-}
-
-func newRootLookuperUnchecked(start string, c client.Client) *RootLookuper {
 	return &RootLookuper{
-		c:     c,
-		Start: start,
-	}
+		l: l,
+	}, nil
 }
 
 // NewRootResolver creates a LookupResolver using iterative lookup from a given root-server,
@@ -100,59 +92,109 @@ func NewRootResolver(start string) (*LookupResolver, error) {
 
 // Lookup performs an iterative lookup
 func (r RootLookuper) Lookup(ctx context.Context, qName string, qType uint16) (*dns.Msg, error) {
-	return r.Iterate(ctx, qName, qType, "")
+	return r.l.Lookup(ctx, qName, qType)
 }
 
 // Exchange queries any root server and validates the response
 func (r RootLookuper) Exchange(ctx context.Context, m *dns.Msg) (*dns.Msg, error) {
-	return r.IterateMsg(ctx, m, "")
+	return r.l.Exchange(ctx, m)
 }
 
-func (r RootLookuper) doExchange(ctx context.Context, m *dns.Msg,
-	server string) (*dns.Msg, error) {
-	// TODO: add cache
-
-	c := r.c
-	if c == nil {
-		c = client.NewDefaultClient(0)
-	}
-
-	resp, _, err := c.ExchangeContext(ctx, m, server)
-	e2 := errors.ValidateResponse(server, resp, err)
-	switch {
-	case e2 == nil, e2.Err == errors.NODATA:
-		// no error or NODATA, we want the resp anyway
-		return resp, nil
-	default:
-		// any other error
-		return nil, e2
-	}
+// DisableAAAA prevents the use of IPv6 entries on NS glue.
+func (r RootLookuper) DisableAAAA() {
+	r.l.DisableAAAA()
 }
 
-// Iterate is an iterative lookup implementation
-func (r RootLookuper) Iterate(ctx context.Context, name string,
-	qtype uint16, startAt string,
-) (*dns.Msg, error) {
+// IteratorLookuper is a generic iterative lookuper, caching zones
+// glue and NS information.
+type IteratorLookuper struct {
+	c    client.Client
+	nsc  *NSCache
+	aaaa bool
+}
+
+// AddRootServers loads the embedded table of root servers,
+// and made persistent.
+func (r *IteratorLookuper) AddRootServers() error {
+	return r.AddMapPersistent(".", 518400, roots)
+}
+
+// AddMap loads NS servers from a map
+func (r *IteratorLookuper) AddMap(qName string, ttl uint32, servers map[string]string) error {
+	if !r.aaaa {
+		// copy and remove AAAA entries
+		m := make(map[string]string)
+		for k, s := range servers {
+			ip, _ := core.ParseAddr(s)
+			if ip.IsValid() && ip.Is4() {
+				m[k] = s
+			}
+		}
+		servers = m
+	}
+	return r.nsc.AddMap(qName, ttl, servers)
+}
+
+// AddMapPersistent loads NS servers from a map but prevents it from being permanently evicted.
+func (r *IteratorLookuper) AddMapPersistent(qName string, ttl uint32,
+	servers map[string]string) error {
+	//
+	err := r.AddMap(qName, ttl, servers)
+	if err != nil {
+		return err
+	}
+
+	return r.nsc.SetPersistence(qName, true)
+}
+
+// AddServer loads NS servers from a list.
+func (*IteratorLookuper) AddServer(string, uint32, ...string) error {
+	return core.ErrNotImplemented
+}
+
+// AddFrom asks the specified server for the NS servers.
+func (*IteratorLookuper) AddFrom(string, uint32, ...string) error {
+	return core.ErrNotImplemented
+}
+
+// DisableAAAA prevents the use of IPv6 entries on NS glue.
+func (r *IteratorLookuper) DisableAAAA() {
+	r.aaaa = false
+}
+
+// SetLogger sets [NSCache]'s logger. [slog.Debug] is used to record
+// when entries are added or removed.
+func (r *IteratorLookuper) SetLogger(log slog.Logger) {
+	r.nsc.SetLogger(log)
+}
+
+// Lookup performs an iterative lookup
+func (r *IteratorLookuper) Lookup(ctx context.Context,
+	name string, qType uint16) (*dns.Msg, error) {
+	//
 	if ctx == nil {
 		return nil, errors.ErrBadRequest()
 	}
 
-	req := exdns.NewRequestFromParts(dns.Fqdn(name), dns.ClassINET, qtype)
-	return r.unsafeIterateMsg(ctx, req, startAt)
+	req := exdns.NewRequestFromParts(dns.Fqdn(name), dns.ClassINET, qType)
+	return r.doIterate(ctx, req)
 }
 
-// IterateMsg is an iterative exchange implementation
-func (r RootLookuper) IterateMsg(ctx context.Context, req *dns.Msg,
-	startAt string,
-) (*dns.Msg, error) {
+// Exchange queries any root server and validates the response
+func (r *IteratorLookuper) Exchange(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
 	if ctx == nil || req == nil {
 		return nil, errors.ErrBadRequest()
 	}
 
 	if q := msgQuestion(req); q != nil {
 		// sanitize request
-		req = exdns.NewRequestFromParts(q.Name, q.Qclass, q.Qtype)
-		return r.unsafeIterateMsg(ctx, req, startAt)
+		req2 := exdns.NewRequestFromParts(q.Name, q.Qclass, q.Qtype)
+
+		// TODO: preserve EDNS0_SUBNET
+		// TODO: any other option useful/safe on the original request to cherry-pick?
+
+		resp, err := r.doIterate(ctx, req2)
+		return exdns.RestoreReturn(req, resp, err)
 	}
 
 	// nothing to answer
@@ -161,87 +203,67 @@ func (r RootLookuper) IterateMsg(ctx context.Context, req *dns.Msg,
 	return msg, nil
 }
 
-func (r RootLookuper) unsafeIterateMsg(ctx context.Context, req *dns.Msg,
-	startAt string,
-) (*dns.Msg, error) {
-	var server string
-
-	switch {
-	case startAt != "":
-		server = startAt
-	case r.Start != "":
-		server = r.Start
-	default:
-		server = pickRoot()
-	}
-
-	return r.doIterate(ctx, req, server)
-}
-
-func (r RootLookuper) doIterate(ctx context.Context, req *dns.Msg,
-	server string,
-) (*dns.Msg, error) {
-	//
+func (r *IteratorLookuper) doIterate(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
 	for {
-		var err error
-		var resp *dns.Msg
-
-		server, resp, err = r.doIteratePass(ctx, req, server)
+		resp, err := r.doIteratePass(ctx, req)
 		switch {
 		case err != nil:
+			// failed
 			return nil, err
-		case resp != nil:
+		case r.responseIsFinal(resp):
 			return resp, nil
 		}
 	}
 }
 
-func (r RootLookuper) doIteratePass(ctx context.Context, req *dns.Msg,
-	server string,
-) (string, *dns.Msg, error) {
-	//
-	server, err := exdns.AsServerAddress(server)
-	if err != nil {
-		return "", nil, err
-	}
-	resp, err := r.doExchange(ctx, req, server)
+func (r *IteratorLookuper) doIteratePass(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
+	resp, err := r.doExchange(ctx, req)
 	switch {
 	case err != nil:
-		return "", nil, err
+		return nil, err
 	case resp == nil:
-		return "", nil, errors.ErrBadResponse()
+		return nil, errors.ErrBadResponse()
 	case resp.Rcode == dns.RcodeSuccess:
 		switch {
 		case len(resp.Answer) > 0:
-			return r.handleSuccessAnswer(ctx, req, resp, server)
+			return r.handleSuccessAnswer(ctx, req, resp)
 		case exdns.HasNsType(resp, dns.TypeNS):
-			return r.handleSuccessDelegation(ctx, req, resp, server)
+			return r.handleSuccessDelegation(ctx, req, resp)
 		case exdns.HasNsType(resp, dns.TypeSOA):
 			return handleSuccessNoData(resp)
 		default:
-			return "", nil, errors.ErrBadResponse()
+			return nil, errors.ErrBadResponse()
 		}
 	default:
-		return "", nil, errors.ErrBadResponse()
+		return nil, errors.ErrBadResponse()
 	}
 }
 
-func handleSuccessNoData(resp *dns.Msg) (string,
-	*dns.Msg, error) {
+func (r *IteratorLookuper) doExchange(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+		return r.nsc.ExchangeWithClient(ctx, req, r.c)
+	}
+}
+
+func handleSuccessNoData(resp *dns.Msg) (*dns.Msg, error) {
 	if resp.Authoritative {
 		// We have a NODATA response with Authority section
 		// from an authoritative server, so pass it on for the Auth section
-		return "", resp, nil
+		return resp, nil
 	}
-	return "", nil, errors.ErrBadResponse()
+
+	return nil, errors.ErrBadResponse()
 }
 
-func (r RootLookuper) handleSuccessAnswer(ctx context.Context,
-	req, resp *dns.Msg, _ string,
-) (string, *dns.Msg, error) {
+func (r *IteratorLookuper) handleSuccessAnswer(ctx context.Context,
+	req, resp *dns.Msg) (*dns.Msg, error) {
+	//
 	if exdns.HasAnswerType(resp, msgQType(req)) {
 		// we got what we asked for
-		return "", resp, nil
+		return resp, nil
 	}
 
 	// we asked for some type but we got back a CNAME so
@@ -251,28 +273,33 @@ func (r RootLookuper) handleSuccessAnswer(ctx context.Context,
 		return r.handleCNAMEAnswer(ctx, req, resp, rr.Target)
 	}
 
-	return "", nil, errors.ErrBadResponse()
+	return nil, errors.ErrBadResponse()
 }
 
-func (r RootLookuper) handleCNAMEAnswer(ctx context.Context,
-	req, resp *dns.Msg, cname string) (string, *dns.Msg, error) {
+func (r *IteratorLookuper) handleCNAMEAnswer(ctx context.Context,
+	req, resp *dns.Msg, cname string) (*dns.Msg, error) {
 	// assemble request for information about the CNAME
 	q := msgQuestion(req)
 	req2 := exdns.NewRequestFromParts(dns.Fqdn(cname), q.Qclass, q.Qtype)
+
+	// reuse OPTs
+	exdns.ForEachRR(req.Extra, func(rr dns.RR) {
+		req2.Extra = append(req2.Extra, rr)
+	})
 
 	// ask
 	resp2, err := r.Exchange(ctx, req2)
 	if err != nil {
 		// failed, return what we had.
-		return "", resp, nil
+		return resp, nil
 	}
 
 	// merge
 	resp3 := r.mergeCNAMEAnswer(resp, resp2)
-	return "", resp3, nil
+	return resp3, nil
 }
 
-func (RootLookuper) mergeCNAMEAnswer(resp1, resp2 *dns.Msg) *dns.Msg {
+func (IteratorLookuper) mergeCNAMEAnswer(resp1, resp2 *dns.Msg) *dns.Msg {
 	resp := resp1.Copy()
 	exdns.ForEachRR(resp2.Answer, func(rr dns.RR) {
 		resp.Answer = append(resp.Answer, rr)
@@ -290,93 +317,219 @@ func (RootLookuper) mergeCNAMEAnswer(resp1, resp2 *dns.Msg) *dns.Msg {
 	return resp
 }
 
-func (r RootLookuper) handleSuccessDelegation(ctx context.Context,
-	_ *dns.Msg, resp *dns.Msg, _ string,
-) (string, *dns.Msg, error) {
-	if len(resp.Extra) < 2 {
-		// name zone
-		server, err := r.getNextServer(ctx, r.getNS(resp.Ns))
-		return server, nil, err
-	}
-
-	// Delegation
-	server, err := r.getNextServer(ctx, r.getA(resp.Extra))
-	return server, nil, err
-}
-
-func (r RootLookuper) getNextServer(ctx context.Context, servers []string) (string, error) {
-	nns, ok := core.SliceRandom(servers)
+func (r *IteratorLookuper) handleSuccessDelegation(ctx context.Context,
+	_, resp *dns.Msg) (*dns.Msg, error) {
+	//
+	ns, ok := exdns.GetFirstRR[*dns.NS](resp.Ns)
 	if !ok {
-		return "", fmt.Errorf("cannot extract nextServer from list")
+		panic("unreachable")
 	}
 
-	server, ok := roots[nns]
-	if !ok {
-		server = nns
-
-		if _, err := netip.ParseAddr(server); err != nil {
-			server, err = r.hostFromRoot(ctx, server)
-			if err != nil {
-				return "", err
-			}
+	name := ns.Header().Name
+	if _, _, ok := r.nsc.Get(name); !ok {
+		// not cached
+		_, err := r.addDelegation(ctx, resp)
+		if err != nil {
+			return nil, err
 		}
 	}
 
-	return server, nil
+	return resp, nil
 }
 
-func (RootLookuper) getA(answers []dns.RR) []string {
-	var out []string
-
-	aaaa := client.HasIPv6Support()
-
-	for _, ref := range answers {
-		switch rr := ref.(type) {
-		case *dns.A:
-			out = append(out, rr.A.String())
-		case *dns.AAAA:
-			if aaaa {
-				out = append(out, rr.AAAA.String())
-			}
-		}
+func (r *IteratorLookuper) addDelegation(ctx context.Context, resp *dns.Msg) (bool, error) {
+	if !r.aaaa {
+		resp = r.responseWithoutAAAA(resp)
 	}
 
-	return out
-}
-
-func (RootLookuper) getNS(answers []dns.RR) []string {
-	var out []string
-
-	for _, ref := range answers {
-		if rr, ok := ref.(*dns.NS); ok {
-			out = append(out, exdns.Decanonize(rr.Ns))
-		}
-	}
-
-	return out
-}
-
-func (r RootLookuper) getOneA(answers []dns.RR) (string, bool) {
-	return core.SliceRandom(r.getA(answers))
-}
-
-func (r RootLookuper) hostFromRoot(ctx context.Context, h string) (string, error) {
-	msg, err := r.Iterate(ctx, h, dns.TypeA, "")
+	zone, err := NewNSCacheZoneFromDelegation(resp)
 	if err != nil {
-		return "", err
+		return false, err
 	}
 
-	result, ok := r.getOneA(msg.Answer)
-	if !ok {
-		return "", fmt.Errorf("cannot select random from answer")
+	err = r.getGlue(ctx, zone)
+	if err == nil {
+		err = r.nsc.Add(zone)
 	}
-	return result, nil
+
+	return err == nil, err
 }
 
-func pickRoot() string {
-	// randomized by range internally
-	for _, x := range roots {
-		return x
+// revive:disable:cognitive-complexity
+func (r *IteratorLookuper) getGlue(ctx context.Context, zone *NSCacheZone) error {
+	// revive:enable:cognitive-complexity
+	var wg sync.WaitGroup
+
+	hasGlue := false
+	zone.ForEachNS(func(qName string, addrs []netip.Addr) {
+		if len(addrs) > 0 {
+			hasGlue = true
+		}
+	})
+
+	if hasGlue {
+		// good enough to start
+		return nil
 	}
-	return ""
+
+	deadline := time.Now().Add(iteratorDeadline)
+	ctx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
+	zone.ForEachNS(func(qName string, addrs []netip.Addr) {
+		switch {
+		case len(addrs) > 0:
+			return
+		case dns.IsSubDomain(zone.name, qName):
+			return
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if r.goGetGlue(ctx, qName, dns.TypeA, zone) {
+				// added
+				hasGlue = true
+			}
+		}()
+
+		if r.aaaa {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if r.goGetGlue(ctx, qName, dns.TypeAAAA, zone) {
+					// added
+					hasGlue = true
+				}
+			}()
+		}
+	})
+	wg.Wait()
+
+	if !hasGlue {
+		// nothing
+		return errors.ErrTimeout(zone.name, nil)
+	}
+
+	return nil
+}
+
+// revive:disable:cognitive-complexity
+func (r *IteratorLookuper) goGetGlue(ctx context.Context,
+	// revive:enable:cognitive-complexity
+	qName string, qType uint16, zone *NSCacheZone) bool {
+	//
+	var addrs []netip.Addr
+
+	resp, err := r.Lookup(ctx, qName, qType)
+	if err != nil {
+		return false
+	}
+
+	eqAddr := func(a, b netip.Addr) bool {
+		return a.Compare(b) == 0
+	}
+
+	exdns.ForEachAnswer(resp, func(rr dns.RR) {
+		var ip netip.Addr
+		var ok bool
+
+		switch qType {
+		case dns.TypeA:
+			ip, ok = r.getIPfromRR(rr)
+		case dns.TypeAAAA:
+			if r.aaaa {
+				ip, ok = r.getIPfromRR(rr)
+			}
+		}
+
+		if ok && !core.SliceContainsFn(addrs, ip, eqAddr) {
+			addrs = append(addrs, ip)
+		}
+	})
+
+	if len(addrs) > 0 {
+		return zone.SetGlue(qName, addrs)
+	}
+	return false
+}
+
+func (*IteratorLookuper) getIPfromRR(rr dns.RR) (netip.Addr, bool) {
+	switch v := rr.(type) {
+	case *dns.A:
+		return netip.AddrFromSlice(v.A)
+	case *dns.AAAA:
+		return netip.AddrFromSlice(v.AAAA)
+	}
+	return netip.Addr{}, false
+}
+
+func (r *IteratorLookuper) responseIsFinal(resp *dns.Msg) bool {
+	q := msgQuestion(resp)
+	if q == nil || len(resp.Answer) > 0 {
+		// no questions, or answers.
+		return true
+	}
+
+	ns, ok := exdns.GetFirstRR[*dns.NS](resp.Ns)
+	if ok {
+		_, _, cached := r.nsc.Get(ns.Hdr.Name)
+		if cached {
+			// another loop
+			return false
+		}
+	}
+
+	return true
+}
+
+func (*IteratorLookuper) responseHasAAAA(resp *dns.Msg) bool {
+	var hasAAAA bool
+
+	exdns.ForEachRR(resp.Answer, func(rr *dns.AAAA) {
+		hasAAAA = true
+	})
+	if hasAAAA {
+		return true
+	}
+
+	exdns.ForEachRR(resp.Extra, func(rr *dns.AAAA) {
+		hasAAAA = true
+	})
+
+	return hasAAAA
+}
+
+func (r *IteratorLookuper) responseWithoutAAAA(resp *dns.Msg) *dns.Msg {
+	if !r.responseHasAAAA(resp) {
+		// return as-is
+		return resp
+	}
+
+	// copy and remove
+	resp2 := resp.Copy()
+	removeAAAA := func(_ []dns.RR, rr dns.RR) (dns.RR, bool) {
+		return rr, rr.Header().Rrtype != dns.TypeAAAA
+	}
+
+	resp2.Answer = core.SliceReplaceFn(resp2.Answer, removeAAAA)
+	resp2.Extra = core.SliceReplaceFn(resp2.Extra, removeAAAA)
+	return resp2
+}
+
+// NewIteratorLookuper creates a new [IteratorLookuper].
+// name and maxRR are used to assemble the [NSCache].
+func NewIteratorLookuper(name string, maxRR uint, c client.Client) *IteratorLookuper {
+	if c == nil {
+		// use default singleflight client
+		c1 := client.NewDefaultClient(0)
+		c = client.NewSingleFlight(c1, 0)
+	}
+
+	iter := &IteratorLookuper{
+		c:    c,
+		nsc:  NewNSCache(name, maxRR),
+		aaaa: client.HasIPv6Support(),
+	}
+	return iter
 }

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -14,6 +14,7 @@ func TestRootLookup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	root.DisableAAAA() // for github sake
 
 	// Simple
 	testRootTypeA(t, root, "karasz.im", "95.216.149.141")


### PR DESCRIPTION
this would become `v0.8.0` to mark the change and a minor regression that `Iterator.AddFrom()`, used by `NewRootLookuper()` when a server is indicated, isn't implemented yet.