### PR TITLE
renovate: prevent Go updates beyond 1.21

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": ["golang-version"],
+      "allowedVersions": "1.21"
+    }
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration for managing Go package versions, allowing only version "1.21".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->